### PR TITLE
When deleting obsolete files, ignore file name patterns we don't understand.

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
@@ -260,6 +260,8 @@ public class DbImpl implements DB
 
         for (File file : Filename.listFiles(databaseDir)) {
             FileInfo fileInfo = Filename.parseFileName(file);
+            if (fileInfo == null)
+              continue;
             long number = fileInfo.getFileNumber();
             boolean keep = true;
             switch (fileInfo.getFileType()) {


### PR DESCRIPTION
This change avoids a `NullPointerException` being thrown in cases where
a file is present in the LevelDB database directory whose name does
not match any of the patterns detected by `Filename#parseFileName()`.
Such files may be placed in the directory by the embedding
application.

Note that the C++ LevelDB implementation already ignores such foreign
files, per how its `leveldb::DBImpl::DeleteObsoleteFiles()` function
calls on the `leveldb::ParseFileName()` function, which is documented to
return false if the given file name is not "a LevelDB file."
