### PR TITLE
Moved the Benchmark app into its own module

### DIFF
--- a/leveldb-benchmark/pom.xml
+++ b/leveldb-benchmark/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>leveldb-project</artifactId>
+    <groupId>org.iq80.leveldb</groupId>
+    <version>0.6-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>leveldb-benchmark</artifactId>
+  <name>leveldb-benchmark</name>
+  <url>http://maven.apache.org</url>
+  <packaging>jar</packaging>
+
+  <description>Port of LevelDB Benchmarks to Java</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>fusesource.nexus.snapshot</id>
+      <name>FuseSource Community Snapshot Repository</name>
+      <url>http://repo.fusesource.com/nexus/content/groups/public-snapshots</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.iq80.leveldb</groupId>
+      <artifactId>leveldb-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.iq80.leveldb</groupId>
+      <artifactId>leveldb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.iq80.leveldb</groupId>
+      <artifactId>leveldb-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.0.4.1</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <excludes>
+            </excludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.2.1</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>java</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <mainClass>org.iq80.leveldb.benchmark.DbBenchmark</mainClass>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/leveldb-benchmark/src/main/java/org/iq80/leveldb/benchmark/DbBenchmark.java
+++ b/leveldb-benchmark/src/main/java/org/iq80/leveldb/benchmark/DbBenchmark.java
@@ -15,17 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.iq80.leveldb;
+package org.iq80.leveldb.benchmark;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
-import com.google.common.io.Closeables;
-import com.google.common.io.Files;
-import org.iq80.leveldb.impl.DbImpl;
-import org.iq80.leveldb.util.*;
+import static com.google.common.base.Charsets.UTF_8;
+import static org.iq80.leveldb.benchmark.DbBenchmark.DBState.EXISTING;
+import static org.iq80.leveldb.benchmark.DbBenchmark.DBState.FRESH;
+import static org.iq80.leveldb.benchmark.DbBenchmark.Order.RANDOM;
+import static org.iq80.leveldb.benchmark.DbBenchmark.Order.SEQUENTIAL;
+import static org.iq80.leveldb.impl.DbConstants.NUM_LEVELS;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,12 +34,27 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Charsets.UTF_8;
-import static org.iq80.leveldb.DbBenchmark.DBState.EXISTING;
-import static org.iq80.leveldb.DbBenchmark.DBState.FRESH;
-import static org.iq80.leveldb.DbBenchmark.Order.RANDOM;
-import static org.iq80.leveldb.DbBenchmark.Order.SEQUENTIAL;
-import static org.iq80.leveldb.impl.DbConstants.NUM_LEVELS;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBFactory;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.Options;
+import org.iq80.leveldb.WriteBatch;
+import org.iq80.leveldb.WriteOptions;
+import org.iq80.leveldb.impl.DbImpl;
+import org.iq80.leveldb.util.FileUtils;
+import org.iq80.leveldb.util.PureJavaCrc32C;
+import org.iq80.leveldb.util.Slice;
+import org.iq80.leveldb.util.SliceOutput;
+import org.iq80.leveldb.util.Slices;
+import org.iq80.leveldb.util.Snappy;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharStreams;
+import com.google.common.io.Closeables;
+import com.google.common.io.Files;
 
 public class DbBenchmark
 {

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>leveldb-api</module>
         <module>leveldb</module>
+        <module>leveldb-benchmark</module>
     </modules>
 
     <inceptionYear>2011</inceptionYear>
@@ -247,9 +248,9 @@
                     </configuration>
                 </plugin>
 
-                <!-- 
-                  Do a license check by running       : mvn license:check  
-                  Update the license check by running : mvn license:format  
+                <!--
+                  Do a license check by running       : mvn license:check
+                  Update the license check by running : mvn license:format
                 -->
                 <plugin>
                     <groupId>com.mycila.maven-license-plugin</groupId>
@@ -315,7 +316,7 @@
                           <windowTitle>${project.name} Source Xref (${project.version})</windowTitle>
                         </configuration>
                       </plugin>
-                      
+
                       <plugin>
                           <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-javadoc-plugin</artifactId>
@@ -348,7 +349,7 @@
                               -->
                               <additionalJOption>-J-Xmx1024m</additionalJOption>
                           </configuration>
-                      </plugin>            
+                      </plugin>
                     </reportPlugins>
                   </configuration>
                 </plugin>


### PR DESCRIPTION
This moves the benchmarks into their own maven module to and allows execution via mvn exec:java.  This allows for easier development of the Benchmarks in its own project separate from the main LevelDB library module. 

Not a huge change but could be useful down the road.  
