### PR TITLE
changed table file extension to .ldb

### DIFF
--- a/leveldb/pom.xml
+++ b/leveldb/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.fusesource.leveldbjni</groupId>
             <artifactId>leveldbjni-all</artifactId>
-            <version>1.1</version>
+            <version>1.8.cs.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/Filename.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/Filename.java
@@ -52,6 +52,14 @@ public class Filename
      */
     public static String tableFileName(long number)
     {
+        return makeFileName(number, "ldb");
+    }
+
+    /**
+     * Return the deprecated name of the sstable with the specified number.
+     */
+    public static String sstTableFileName(long number)
+    {
         return makeFileName(number, "sst");
     }
 

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/TableCache.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/TableCache.java
@@ -119,11 +119,17 @@ public class TableCache
             try{
                fileChannel = new FileInputStream(tableFile).getChannel();
             }
-            catch(FileNotFoundException e){
-               // attempt to open older .sst extension
-               tableFileName = Filename.sstTableFileName(fileNumber);
-               tableFile = new File(databaseDir, tableFileName);
-               fileChannel = new FileInputStream(tableFile).getChannel();
+            catch(FileNotFoundException ldbNotFound){
+               try{
+                  // attempt to open older .sst extension
+                  tableFileName = Filename.sstTableFileName(fileNumber);
+                  tableFile = new File(databaseDir, tableFileName);
+                  fileChannel = new FileInputStream(tableFile).getChannel();
+               }
+               catch(FileNotFoundException sstNotFound){
+                  throw new FileNotFoundException("Neither " + Filename.tableFileName(fileNumber)
+                        + " nor " + tableFileName + " could be found");
+               }
             }
 
             try {


### PR DESCRIPTION
the latest c++ leveldb uses the file extension .ldb for its table files (for some windows compatibility issue). I've switched the filenames to also use the .ldb extension to resolve compatibility. The .sst extension will still be recognized in opening files. Also changed a pom to include the latest jni-leveldb (which uses a more recent c++ backend) so that interop tests with the new extension will work