### PR TITLE
deal with null here - happens e.g. when platform is android

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/impl/Iq80DBFactory.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/Iq80DBFactory.java
@@ -29,12 +29,12 @@ import java.io.*;
  */
 public class Iq80DBFactory implements DBFactory {
 
-    public static final int CPU_DATA_MODEL = Integer.getInteger("sun.arch.data.model");
+    public static final Integer CPU_DATA_MODEL = Integer.getInteger("sun.arch.data.model");
 
     // We only use MMAP on 64 bit systems since it's really easy to run out of
     // virtual address space on a 32 bit system when all the data is getting mapped
     // into memory.  If you really want to use MMAP anyways, use -Dleveldb.mmap=true
-    public static final boolean USE_MMAP = Boolean.parseBoolean(System.getProperty("leveldb.mmap", ""+(CPU_DATA_MODEL>32)));
+    public static final boolean USE_MMAP = Boolean.parseBoolean(System.getProperty("leveldb.mmap", ""+(CPU_DATA_MODEL!=null && CPU_DATA_MODEL>32)));
 
     public static final String VERSION;
     static {


### PR DESCRIPTION
there was a workaround described by @romanman for #43 and the issue was closed. But we can avoid the crash in the first place by dealing with the null-value that is possible here