### PR TITLE
Allow FileChannelTable to work with files larger than Integer.MAX_VALUE

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/table/MMapTable.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/table/MMapTable.java
@@ -17,6 +17,7 @@
  */
 package org.iq80.leveldb.table;
 
+import com.google.common.base.Preconditions;
 import org.iq80.leveldb.util.ByteBufferSupport;
 import org.iq80.leveldb.util.Closeables;
 import org.iq80.leveldb.util.Slice;
@@ -44,6 +45,8 @@ public class MMapTable
             throws IOException
     {
         super(name, fileChannel, comparator, verifyChecksums);
+        long size = fileChannel.size();
+        Preconditions.checkArgument(size <= Integer.MAX_VALUE, "File must be smaller than %s bytes", Integer.MAX_VALUE);
     }
 
     @Override

--- a/leveldb/src/main/java/org/iq80/leveldb/table/Table.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/table/Table.java
@@ -49,7 +49,6 @@ public abstract class Table
         Preconditions.checkNotNull(fileChannel, "fileChannel is null");
         long size = fileChannel.size();
         Preconditions.checkArgument(size >= Footer.ENCODED_LENGTH, "File is corrupt: size must be at least %s bytes", Footer.ENCODED_LENGTH);
-        Preconditions.checkArgument(size <= Integer.MAX_VALUE, "File must be smaller than %s bytes", Integer.MAX_VALUE);
         Preconditions.checkNotNull(comparator, "comparator is null");
 
         this.name = name;


### PR DESCRIPTION
`Table`'s constructor had a precondition check to assert that the SSTable file size is `<= Integer.MAX_VALUE`. This change moves this check to `MMapTable`, as the check is only required there, for memory-mapping the file.

In this way, one can use the `FileChannelTable` subclass of `Table` for files with sizes larger than `Integer.MAX_VALUE`.