### PR TITLE
Close FileInputStream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+  - oraclejdk8

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
@@ -517,7 +517,8 @@ public class DbImpl
     {
         Preconditions.checkState(mutex.isHeldByCurrentThread());
         File file = new File(databaseDir, Filename.logFileName(fileNumber));
-        try (FileChannel channel = new FileInputStream(file).getChannel()) {
+        try (FileInputStream fis = new FileInputStream(file);
+             FileChannel channel = fis.getChannel()) {
             LogMonitor logMonitor = LogMonitors.logMonitor();
             LogReader logReader = new LogReader(channel, logMonitor, true, 0);
 

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/VersionSet.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/VersionSet.java
@@ -342,7 +342,8 @@ public class VersionSet
         currentName = currentName.substring(0, currentName.length() - 1);
 
         // open file channel
-        try (FileChannel fileChannel = new FileInputStream(new File(databaseDir, currentName)).getChannel()) {
+        try (FileInputStream fis = new FileInputStream(new File(databaseDir, currentName));
+             FileChannel fileChannel = fis.getChannel()) {
             // read log edit log
             Long nextFileNumber = null;
             Long lastSequence = null;

--- a/leveldb/src/test/java/org/iq80/leveldb/impl/LogTest.java
+++ b/leveldb/src/test/java/org/iq80/leveldb/impl/LogTest.java
@@ -18,7 +18,6 @@
 package org.iq80.leveldb.impl;
 
 import com.google.common.collect.ImmutableList;
-import org.iq80.leveldb.util.Closeables;
 import org.iq80.leveldb.util.Slice;
 import org.iq80.leveldb.util.SliceOutput;
 import org.iq80.leveldb.util.Slices;
@@ -139,17 +138,15 @@ public class LogTest
         }
 
         // test readRecord
-        FileChannel fileChannel = new FileInputStream(writer.getFile()).getChannel();
-        try {
+
+        try (FileInputStream fis = new FileInputStream(writer.getFile());
+             FileChannel fileChannel = fis.getChannel();) {
             LogReader reader = new LogReader(fileChannel, NO_CORRUPTION_MONITOR, true, 0);
             for (Slice expected : records) {
                 Slice actual = reader.readRecord();
                 assertEquals(actual, expected);
             }
             assertNull(reader.readRecord());
-        }
-        finally {
-            Closeables.closeQuietly(fileChannel);
         }
     }
 

--- a/leveldb/src/test/java/org/iq80/leveldb/impl/TestFileChannelLogWriter.java
+++ b/leveldb/src/test/java/org/iq80/leveldb/impl/TestFileChannelLogWriter.java
@@ -17,15 +17,15 @@
  */
 package org.iq80.leveldb.impl;
 
-import org.iq80.leveldb.util.Slice;
-import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.channels.FileChannel;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import org.iq80.leveldb.util.Slice;
+import org.testng.annotations.Test;
 
 public class TestFileChannelLogWriter
 {
@@ -44,16 +44,16 @@ public class TestFileChannelLogWriter
 
             LogMonitor logMonitor = new AssertNoCorruptionLogMonitor();
 
-            FileChannel channel = new FileInputStream(file).getChannel();
-
-            LogReader logReader = new LogReader(channel, logMonitor, true, 0);
-
-            int count = 0;
-            for (Slice slice = logReader.readRecord(); slice != null; slice = logReader.readRecord()) {
-                assertEquals(slice.length(), recordSize);
-                count++;
+            try (FileInputStream fis = new FileInputStream(file);
+                 FileChannel channel = fis.getChannel();) {
+                LogReader logReader = new LogReader(channel, logMonitor, true, 0);
+                int count = 0;
+                for (Slice slice = logReader.readRecord(); slice != null; slice = logReader.readRecord()) {
+                    assertEquals(slice.length(), recordSize);
+                    count++;
+                }
+                assertEquals(count, 1);
             }
-            assertEquals(count, 1);
         }
         finally {
             file.delete();


### PR DESCRIPTION
Having lots of data written into the database, the database ran into "Too many open files". In order to correct this, the FileInputStreams should be closed via the AutoCloseable...
(Also with this fix, maxOpenFiles should work as the FileInputStreams of the cache get properly released, see Bug #37 )

