### PR TITLE
Update unmap support to latest Java 9

### DIFF
--- a/leveldb/pom.xml
+++ b/leveldb/pom.xml
@@ -154,6 +154,7 @@
                         <option>-dontwarn org.xerial.snappy.SnappyLoader</option>
                         <option>-dontwarn org.xerial.snappy.SnappyBundleActivator</option>
                         <option>-dontwarn org.iq80.snappy.HadoopSnappyCodec**</option>
+                        <option>-dontwarn org.iq80.leveldb.util.ByteBufferSupport</option>
                         <option>-dontoptimize</option>
                     </options>
                 </configuration>


### PR DESCRIPTION
jdk9+148 changed visibility rules in a way that breaks the previous
mechanism for invoking the mapped bytebuffer cleaner.

In later versions, a new method (Unsafe.invokeCleaner) is available
as a workaround (https://bugs.openjdk.java.net/browse/JDK-8171377)