### PR TITLE
Allow `LogReader` to take an `InputStream` rather than a `FileChannel`

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
@@ -519,10 +519,9 @@ public class DbImpl
     {
         checkState(mutex.isHeldByCurrentThread());
         File file = new File(databaseDir, Filename.logFileName(fileNumber));
-        try (FileInputStream fis = new FileInputStream(file);
-                FileChannel channel = fis.getChannel()) {
+        try (FileInputStream fis = new FileInputStream(file)) {
             LogMonitor logMonitor = LogMonitors.logMonitor();
-            LogReader logReader = new LogReader(channel, logMonitor, true, 0);
+            LogReader logReader = new LogReader(fis, logMonitor, true, 0);
 
             // Log(options_.info_log, "Recovering log #%llu", (unsigned long long) log_number);
 

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/VersionSet.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/VersionSet.java
@@ -33,7 +33,6 @@ import org.iq80.leveldb.util.Slice;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -343,8 +342,7 @@ public class VersionSet
         currentName = currentName.substring(0, currentName.length() - 1);
 
         // open file channel
-        try (FileInputStream fis = new FileInputStream(new File(databaseDir, currentName));
-             FileChannel fileChannel = fis.getChannel()) {
+        try (FileInputStream fis = new FileInputStream(new File(databaseDir, currentName))) {
             // read log edit log
             Long nextFileNumber = null;
             Long lastSequence = null;
@@ -352,7 +350,7 @@ public class VersionSet
             Long prevLogNumber = null;
             Builder builder = new Builder(this, current);
 
-            LogReader reader = new LogReader(fileChannel, throwExceptionMonitor(), true, 0);
+            LogReader reader = new LogReader(fis, throwExceptionMonitor(), true, 0);
             for (Slice record = reader.readRecord(); record != null; record = reader.readRecord()) {
                 // read version edit
                 VersionEdit edit = new VersionEdit(record);

--- a/leveldb/src/test/java/org/iq80/leveldb/impl/LogTest.java
+++ b/leveldb/src/test/java/org/iq80/leveldb/impl/LogTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -139,9 +138,8 @@ public class LogTest
 
         // test readRecord
 
-        try (FileInputStream fis = new FileInputStream(writer.getFile());
-                FileChannel fileChannel = fis.getChannel()) {
-            LogReader reader = new LogReader(fileChannel, NO_CORRUPTION_MONITOR, true, 0);
+        try (FileInputStream fis = new FileInputStream(writer.getFile())) {
+            LogReader reader = new LogReader(fis, NO_CORRUPTION_MONITOR, true, 0);
             for (Slice expected : records) {
                 Slice actual = reader.readRecord();
                 assertEquals(actual, expected);

--- a/leveldb/src/test/java/org/iq80/leveldb/impl/TestFileChannelLogWriter.java
+++ b/leveldb/src/test/java/org/iq80/leveldb/impl/TestFileChannelLogWriter.java
@@ -22,7 +22,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.nio.channels.FileChannel;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -44,9 +43,8 @@ public class TestFileChannelLogWriter
 
             LogMonitor logMonitor = new AssertNoCorruptionLogMonitor();
 
-            try (FileInputStream fis = new FileInputStream(file);
-                    FileChannel channel = fis.getChannel()) {
-                LogReader logReader = new LogReader(channel, logMonitor, true, 0);
+            try (FileInputStream fis = new FileInputStream(file)) {
+                LogReader logReader = new LogReader(fis, logMonitor, true, 0);
                 int count = 0;
                 for (Slice slice = logReader.readRecord(); slice != null; slice = logReader.readRecord()) {
                     assertEquals(slice.length(), recordSize);

--- a/leveldb/src/test/java/org/iq80/leveldb/impl/TestMMapLogWriter.java
+++ b/leveldb/src/test/java/org/iq80/leveldb/impl/TestMMapLogWriter.java
@@ -22,7 +22,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.nio.channels.FileChannel;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -44,9 +43,9 @@ public class TestMMapLogWriter
 
             LogMonitor logMonitor = new AssertNoCorruptionLogMonitor();
 
-            FileChannel channel = new FileInputStream(file).getChannel();
+            FileInputStream fis = new FileInputStream(file);
 
-            LogReader logReader = new LogReader(channel, logMonitor, true, 0);
+            LogReader logReader = new LogReader(fis, logMonitor, true, 0);
 
             int count = 0;
             for (Slice slice = logReader.readRecord(); slice != null; slice = logReader.readRecord()) {


### PR DESCRIPTION
We are in a situation where materialising a file would be awkward and it seems like it might not be necessary :-)