### PR TITLE
Fixes #96 - Removed autoclose of FileChannel.

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/impl/TableCache.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/TableCache.java
@@ -127,6 +127,8 @@ public class TableCache
                 FileChannel fileChannel = fis.getChannel();
                 if (Iq80DBFactory.USE_MMAP) {
                     table = new MMapTable(tableFile.getAbsolutePath(), fileChannel, userComparator, verifyChecksums);
+                    // We can close the channel and input stream as the mapping does not need them
+                    Closeables.closeQuietly(fis);
                 }
                 else {
                     table = new FileChannelTable(tableFile.getAbsolutePath(), fileChannel, userComparator, verifyChecksums);


### PR DESCRIPTION
This fix allows LevelDB to run on a 32 bit arch such as the Raspberry Pi.