### PR TITLE
compress Slice when create filemetadata

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/impl/FileMetaData.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/FileMetaData.java
@@ -48,8 +48,8 @@ public class FileMetaData
     {
         this.number = number;
         this.fileSize = fileSize;
-        this.smallest = smallest;
-        this.largest = largest;
+        this.smallest = smallest.compressed();
+        this.largest = largest.compressed();
     }
 
     public long getFileSize()

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/InternalKey.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/InternalKey.java
@@ -140,4 +140,8 @@ public class InternalKey
     {
         return data.slice(0, data.length() - SIZE_OF_LONG);
     }
+
+    public InternalKey compressed() {
+        return new InternalKey(this.userKey.compressed(), sequenceNumber, valueType);
+    }
 }

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/InternalKey.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/InternalKey.java
@@ -141,7 +141,8 @@ public class InternalKey
         return data.slice(0, data.length() - SIZE_OF_LONG);
     }
 
-    public InternalKey compressed() {
+    public InternalKey compressed()
+    {
         return new InternalKey(this.userKey.compressed(), sequenceNumber, valueType);
     }
 }

--- a/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
@@ -43,6 +43,10 @@ import static org.iq80.leveldb.util.SizeOf.SIZE_OF_SHORT;
 public final class Slice
         implements Comparable<Slice>
 {
+    // compressed will return compressed slice when data.length - length >= 1kb
+    // this will avoid oom ex when append too large file metadata
+    static final int COMPRESSION_THRESHOLD = 1024 ;
+
     private final byte[] data;
     private final int offset;
     private final int length;
@@ -716,5 +720,14 @@ public final class Slice
         return getClass().getSimpleName() + '(' +
                 "length=" + length() +
                 ')';
+    }
+
+    // get compressed slice
+    public Slice compressed() {
+        if(this.data.length - length < COMPRESSION_THRESHOLD)
+            return this;
+        byte[] tmp = new byte[this.length];
+        System.arraycopy(data, offset, tmp, 0, length);
+        return new Slice(tmp);
     }
 }

--- a/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
@@ -43,8 +43,6 @@ import static org.iq80.leveldb.util.SizeOf.SIZE_OF_SHORT;
 public final class Slice
         implements Comparable<Slice>
 {
-    // compressed will return compressed slice when data.length - length >= 1kb
-    // this will avoid oom ex when append too large file metadata
     static final int COMPRESSION_THRESHOLD = 1024 ;
 
     private final byte[] data;
@@ -724,8 +722,9 @@ public final class Slice
 
     // get compressed slice
     public Slice compressed() {
-        if(this.data.length - length < COMPRESSION_THRESHOLD)
+        if(this.data.length - length < COMPRESSION_THRESHOLD) {
             return this;
+        }
         return new Slice(getBytes());
     }
 }

--- a/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
@@ -726,8 +726,6 @@ public final class Slice
     public Slice compressed() {
         if(this.data.length - length < COMPRESSION_THRESHOLD)
             return this;
-        byte[] tmp = new byte[this.length];
-        System.arraycopy(data, offset, tmp, 0, length);
-        return new Slice(tmp);
+        return new Slice(getBytes());
     }
 }

--- a/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/util/Slice.java
@@ -43,7 +43,7 @@ import static org.iq80.leveldb.util.SizeOf.SIZE_OF_SHORT;
 public final class Slice
         implements Comparable<Slice>
 {
-    static final int COMPRESSION_THRESHOLD = 1024 ;
+    static final int COMPRESSION_THRESHOLD = 1024;
 
     private final byte[] data;
     private final int offset;
@@ -720,9 +720,12 @@ public final class Slice
                 ')';
     }
 
-    // get compressed slice
-    public Slice compressed() {
-        if(this.data.length - length < COMPRESSION_THRESHOLD) {
+    /**
+     * get compressed slice if data.length - length >= 1kb
+     */
+    public Slice compressed()
+    {
+        if (this.data.length - length < COMPRESSION_THRESHOLD) {
             return this;
         }
         return new Slice(getBytes());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17157439/119598555-bf6b4100-be15-11eb-9c93-1b93c00ba09b.png)

when DbImpl used as singleton bean in spring application context for a long time, the oom ex occured
after inspect the heap dump file
i found the actually length of filemetadata.largest.userKey is 33, while size of filemetadata.largest.userKey.data is 10485kb