### PR TITLE
Fix an issue where a large byte array may get pinned down in memory

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/impl/FileMetaData.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/FileMetaData.java
@@ -17,6 +17,8 @@
  */
 package org.iq80.leveldb.impl;
 
+import org.iq80.leveldb.util.Slice;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class FileMetaData
@@ -48,8 +50,14 @@ public class FileMetaData
     {
         this.number = number;
         this.fileSize = fileSize;
-        this.smallest = smallest;
-        this.largest = largest;
+        // Copy bytes of the key from slice so the byte array backing the slice can be freed.
+        // This is necessary to avoid pinning down the byte array which could be large because of
+        // containing both key and value.
+        this.smallest = new InternalKey(new Slice(smallest.getUserKey().getBytes()),
+                                        smallest.getSequenceNumber(), smallest.getValueType());
+
+        this.largest = new InternalKey(new Slice(largest.getUserKey().getBytes()),
+                                       largest.getSequenceNumber(), largest.getValueType());
     }
 
     public long getFileSize()


### PR DESCRIPTION
which could lead to out of memory.

Why:
FileMetadata stores smallest and largest key internally to identity
the start and end key range in a given file. The key is essentially
a slice of a byte array storing a key-value entry. This causes
the byte array to be pinned down in memory, which can be an issue
when the value is fairly large. Eventually this can lead to
out of memory.

What:
The change is to make a copy of the key (which should be typically
small) into a new byte array so the original byte array
(which can be large) can be freed.